### PR TITLE
Adding svg, scale, and axis components

### DIFF
--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -1,27 +1,278 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../px-vis/px-vis-scale.html">
+<link rel="import" href="../px-vis/px-vis-svg.html">
+<link rel="import" href="../px-vis/px-vis-bar-svg.html">
+<link rel="import" href="../px-vis/px-vis-axis.html">
 
 <link rel="import" href="../px-vis/px-vis-behavior-common.html">
 
 
 <dom-module id="px-vis-boxplot">
   <template>
-    My test value is: [[testProp]]
+    <px-vis-svg
+      width="[[width]]"
+      height="[[height]]"
+      margin="[[margin]]"
+      svg="{{svg}}">
+    </px-vis-svg>
+    <px-vis-scale
+      x-axis-type="scaleBand"
+      y-axis-type="linear"
+      complete-series-config="[[completeSeriesConfig]]"
+      chart-extents="[[_returnChartExtents(dataset)]]"
+      data-extents="[[dataExtents]]"
+      width="[[width]]"
+      height="[[height]]"
+      margin="[[margin]]"
+      chart-data="{{_returnChartData(dataset)}}"
+      x="{{xCol}}"
+      y="{{yCol}}"
+      domain-changed="{{svgDomainChanged}}">
+    </px-vis-scale>
+    <!-- y axis -->
+    <px-vis-axis
+      svg="[[svg]]"
+      axis="[[yCol]]"
+      margin="[[margin]]"
+      width="[[width]]"
+      height="[[height]]"
+      title="Y Axis"
+      orientation="left"
+      label-position="center"
+      complete-series-config="[[completeSeriesConfig]]"
+      muted-series=[[mutedSeries]]
+      domain-changed="[[svgDomainChanged]]">
+    </px-vis-axis>
+    <!-- x axis -->
+    <px-vis-axis
+      svg="[[svg]]"
+      axis="[[xCol]]"
+      margin="[[margin]]"
+      width="[[width]]"
+      height="[[height]]"
+      title="X Axis"
+      orientation="bottom"
+      label-position="center"
+      complete-series-config="[[completeSeriesConfig]]"
+      muted-series=[[mutedSeries]]
+      domain-changed="[[svgDomainChanged]]">
+    </px-vis-axis>
   </template>
   <script>
     Polymer({
 
       is: "px-vis-boxplot",
 
+      behaviors: [
+        PxColorsBehavior.dataVisColors,
+        PxColorsBehavior.dataVisColorTheming,
+        PxColorsBehavior.getSeriesColors
+      ],
+
       properties:{
-        testProp: {
+
+        width: {
+          type : Number,
+          value : 500
+        },
+
+        height:{
+          type : Number,
+          value : 200
+        },
+
+        margin:{
+          type : Object,
+          value : function() {
+            return {
+              "top": 10,
+              "right": 10,
+              "bottom": 50,
+              "left": 50
+            }
+          }
+        },
+
+        svgDomainChanged:{
+          type: Boolean
+        },
+
+        singleChartData:{
+          type : Array,
+          value : function() {
+            return [{
+              'x': "A",
+              'y': 0.56
+            },{
+              'x': "B",
+              'y': 0.4
+            },{
+              'x': "C",
+              'y': 0.43
+            },{
+              'x': "D",
+              'y': 0.33
+            },{
+              'x': "E",
+              'y': 0.47
+            },{
+              'x': "F",
+              'y': 0.41
+            }]
+          }
+        },
+
+        multiChartData:{
+          type : Array,
+          value : function() {
+            return [{
+              'x': "A",
+              'y': 0.56,
+              'y1': 0.3,
+              'y2': 0.1
+            },{
+              'x': "B",
+              'y': 0.4,
+              'y1': 0.4,
+              'y2': 0.2
+            },{
+              'x': "C",
+              'y': 0.43,
+              'y1': 0.3,
+              'y2': 0.3
+            },{
+              'x': "D",
+              'y': 0.33,
+              'y1': 0.4,
+              'y2': 0.5
+            },{
+              'x': "E",
+              'y': 0.47,
+              'y1': 0.4,
+              'y2': 0.6
+            },{
+              'x': "F",
+              'y': 0.41,
+              'y1': 0.2,
+              'y2': 0.5
+            }]
+          }
+        },
+
+        completeSeriesConfig: {
+          type : Object
+        },
+
+        dataExtents:{
+          type : Object,
+          value:{}
+        },
+
+        dataset: {
           type: String,
-          value: 'test'
+          value: "single"
+        },
+
+        _colorsAreSet: {
+          type: Boolean,
+          value: false
         }
       },
 
-      ready: function() {
+      observers: [
+        '_updateCompleteSeriesConfig(_colorsAreSet, dataset, type)'
+      ],
 
+      listeners: {
+        "px-data-vis-colors-applied" : '_colorsSet'
+      },
+
+      _colorsSet: function() {
+        this.set('_colorsAreSet', true);
+      },
+
+      /**
+      * Gets the charts extent config (the max and min values for both x and y values).
+      */
+      _returnChartExtents: function() {
+        var linear = (this.dataset === 'multi') ? [0,1.6] : [0,0.6],
+            ordinal = ["A", "B","C","D","E","F"];
+        return {
+            "x": ordinal,
+            "y": linear,
+          }
+      },
+
+      /**
+      * Gets raw chart data which is used for most px vis components.
+      */
+      _returnChartData: function() {
+        return (this.dataset === 'multi') ? this.multiChartData : this.singleChartData;
+      },
+
+      _updateCompleteSeriesConfig: function() {
+        this.debounce("_updateCompleteSeriesConfig", function() {
+          if(this._colorsAreSet) {
+            if(this.dataset === 'multi') {
+              this.set('completeSeriesConfig', {
+                'mySeries': {
+                  "name":"My-Series",
+                  "type": "bar",
+                  "x": 'x',
+                  "y": 'y',
+                  'color': this._getColor(0)
+                },
+                'mySeries2': {
+                  "name":"My-Series2",
+                  "type": "bar",
+                  "x": 'x',
+                  "y": 'y1',
+                  'color': this._getColor(1)
+                },
+                'mySeries3': {
+                  "name":"My-Series3",
+                  "type": "bar",
+                  "x": 'x',
+                  "y": 'y2',
+                  'color': this._getColor(2)
+                },
+              });
+            } else {
+              this.set('completeSeriesConfig', {
+                'mySeries': {
+                  "name":"My-Series",
+                  "type": "bar",
+                  "x": 'x',
+                  "y": 'y',
+                  'color': this._getColor(0)
+                }
+              });
+            }
+          }
+        }, 10);
+      },
+
+
+
+      /**
+      * Gets the chart data formatted using the Px.D3 stack. For px vis bar components,
+      * the chart data must be processed this way.
+      */
+      _returnStackData: function() {
+        var cd = this._returnChartData();
+        return this._returnStack(cd);
+      },
+
+      /**
+      * Formats chart data with Px.D3 stack.
+      */
+      _returnStack: function(chartData) {
+        var stack = Px.d3.stack(),
+            keys = (this.dataset === 'multi') ? ["y", "y1", "y2"] : ["y"];
+        stack.keys(keys);
+        return stack(chartData);
       }
+
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Adding basic components that almost all charts will need.  I took the code from my working bar chart component.  There is also hardcoded data objects right now.

 - px-vis-svg: drawable area 
 - px-vis-scale: handles size calculations, allowing scaling to be applied to entire chart
 - px-vis-axis: axis component for x and y axis
  