### PR TITLE
Using domainChanged for size changes

### DIFF
--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -14,7 +14,8 @@
       behaviors: [
         PxVisBehavior.commonMethods,
         PxVisBehavior.svgDefinition,
-        PxVisBehaviorD3.axes
+        PxVisBehaviorD3.axes,
+        PxVisBehaviorD3.domainUpdate
       ],
 
       properties: {
@@ -123,7 +124,7 @@
       },
 
       observers: [
-        'draw(data, position, svg, x, y, boxWidth, edgeWidth, outlierRadius, meanRadius)',
+        'draw(data, position, svg, x, y, domainChanged, boxWidth, edgeWidth, outlierRadius, meanRadius)',
         '_updateColors(fillColor, strokeColor, medianStrokeColor, meanFillColor, outlierFillColor)'
       ],
 

--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -72,6 +72,7 @@
         svg="[[svg]]"
         x="[[x]]"
         y="[[y]]"
+        domain-changed="[[domainChanged]]"
         box-width="[[boxWhiskerConfig.boxWidth]]"
         edge-width="[[boxWhiskerConfig.edgeWidth]]"
         fill-color="[[boxWhiskerConfig.fillColor]]"
@@ -190,7 +191,6 @@
 
       observers: [
         '_boxWhiskerConfigChanged(boxWhiskerConfig)',
-        '_sizeChanged(width, height)',
         '_updateSeriesConfig(_colorsAreSet)'
       ],
 
@@ -277,17 +277,6 @@
             });
           }
         }, 10);
-      },
-
-      _sizeChanged: function() {
-        const comps = this.shadowRoot.querySelectorAll('px-vis-box-whisker');
-        if (comps) {
-          comps.forEach(function(comp) {
-            // x and y changes are not triggering on the box whisker components,
-            // so this is here for now to force a re-draw when the chart size changes
-            comp.draw();
-          });
-        }
       },
 
       _colorsSet: function() {


### PR DESCRIPTION
The domainChanged prop is used to watch for changes to the x and y functions (val to pixel coord functions).  I removed my previous size listener and replaced with the proper way using the domainChanged prop.