### PR TITLE
Use register branch, add vert threshold, add multi layer svg

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "polymer": "#1.9 - 2",
-    "px-vis": "^4.6.0",
+    "px-vis": "register",
     "iron-resizable-behavior": "^2.0.0",
     "app-localize-behavior": "^2.0.0"
   },

--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -27,7 +27,7 @@
       width="[[width]]"
       height="[[height]]"
       margin="[[margin]]"
-      chart-data="[[_emptyChartData]]"
+      chart-data="[[chartData]]"
       x="{{x}}"
       y="{{y}}"
       domain-changed="{{domainChanged}}">
@@ -35,7 +35,7 @@
     <!-- y axis -->
     <px-vis-axis
       id="yAxis"
-      svg="[[svg]]"
+      svg="[[layer.1]]"
       axis="[[y]]"
       margin="[[margin]]"
       width="[[width]]"
@@ -43,6 +43,7 @@
       title="Y Axis"
       orientation="left"
       label-position="center"
+      prevent-series-bar
       complete-series-config="[[completeSeriesConfig]]"
       muted-series=[[mutedSeries]]
       domain-changed="[[domainChanged]]">
@@ -50,7 +51,7 @@
     <!-- x axis -->
     <px-vis-axis
       id="xAxis"
-      svg="[[svg]]"
+      svg="[[layer.1]]"
       axis="[[x]]"
       margin="[[margin]]"
       width="[[width]]"
@@ -58,6 +59,7 @@
       title="X Axis"
       orientation="bottom"
       label-position="center"
+      prevent-series-bar
       complete-series-config="[[completeSeriesConfig]]"
       muted-series=[[mutedSeries]]
       domain-changed="[[domainChanged]]">
@@ -68,7 +70,7 @@
         data="[[item.data]]"
         position="[[item.position]]"
         orientation="[[orientation]]"
-        svg="[[svg]]"
+        svg="[[layer.1]]"
         x="[[x]]"
         y="[[y]]"
         domain-changed="[[domainChanged]]"
@@ -87,13 +89,16 @@
     <!-- threshold lines -->
     <px-vis-threshold
       id="threshold"
-      svg="[[svg]]"
+      svg="[[layer.2]]"
       complete-series-config="[[completeSeriesConfig]]"
       threshold-data="[[thresholdData]]"
       threshold-config="[[thresholdConfig]]"
       width="[[width]]"
+      height="[[height]]"
       margin="[[margin]]"
+      x="[[x]]"
       y="[[y]]"
+      type="[[_thresholdType]]"
       domain-changed="[[domainChanged]]"
       show-threshold-box="[[showThresholdBox]]"
       language="[[language]]">
@@ -120,6 +125,7 @@
         PxVisBehavior.thresholds,
         PxVisBehaviorD3.domainUpdate,
         PxVisBehaviorChart.axisConfigs,
+        PxVisBehaviorChart.layers,
         PxVisBehaviorChart.subConfiguration,
         PxVisBehaviorChart.thresholdConfig
       ],
@@ -186,24 +192,16 @@
           value: 'vertical'
         },
 
+        _thresholdType: {
+          type: String,
+          value: 'y'
+        },
+
         _colorsAreSet: {
           type: Boolean,
           value: false
-        },
-
-        /**
-         * Some of px components require raw chart data to work properly.
-         * We use this in order to simply satisfy the existance of 'chart data'.
-         */
-        _emptyChartData: {
-          type: Array,
-          value: function() {
-            return [{
-              'x': 0,
-              'y': 0
-            }];
-          }
         }
+
       },
 
       observers: [
@@ -220,6 +218,10 @@
         'px-data-vis-colors-applied': '_colorsSet'
       },
 
+      ready: function() {
+        this.set('numberOfLayers', 5);
+      },
+
       _chartDataChanged: function(chartData) {
         if (!chartData || chartData.length < 1) {
           return;
@@ -231,15 +233,17 @@
         if (!this.chartData || this.chartData.length < 1) {
           return;
         }
-        // update axis types
+        // update axis and threshold types
         if (orientation === 'horizontal') {
           // TODO: x axis should be scaleBand
           this.xAxisType = 'linear';
           this.yAxisType = 'linear';
+          this._thresholdType = 'x';
         } else {
           // TODO: y axis should be scaleBand
           this.xAxisType = 'linear';
           this.yAxisType = 'linear';
+          this._thresholdType = 'y';
         }
         // update extents
         this.dataExtents = this._calcDataExtents(this.chartData);
@@ -321,8 +325,8 @@
             this.set('completeSeriesConfig', {
               'mySeries': {
                 'name': 'My-Series',
-                'x': 'x',
-                'y': 'y',
+                'x': 'position',
+                'y': 'data',
                 'color': this._getColor(0)
               }
             });

--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -37,6 +37,7 @@
       id="yAxis"
       svg="[[layer.1]]"
       axis="[[y]]"
+      axis-type="[[yAxisType]]"
       margin="[[margin]]"
       width="[[width]]"
       height="[[height]]"
@@ -53,6 +54,7 @@
       id="xAxis"
       svg="[[layer.1]]"
       axis="[[x]]"
+      axis-type="[[xAxisType]]"
       margin="[[margin]]"
       width="[[width]]"
       height="[[height]]"
@@ -98,7 +100,7 @@
       margin="[[margin]]"
       x="[[x]]"
       y="[[y]]"
-      type="[[_thresholdType]]"
+      type="[[thresholdType]]"
       domain-changed="[[domainChanged]]"
       show-threshold-box="[[showThresholdBox]]"
       language="[[language]]">
@@ -192,7 +194,13 @@
           value: 'vertical'
         },
 
-        _thresholdType: {
+        /**
+         * Sets the orientation of the threshold line. Applicable values:
+         *
+         * `x`: Threshold line will be vertical. Aligning with a value on the x-axis.
+         * `y`: Threshold line will be horizontal. Aligning with a value on the y-axis.
+         */
+        thresholdType: {
           type: String,
           value: 'y'
         },
@@ -235,15 +243,13 @@
         }
         // update axis and threshold types
         if (orientation === 'horizontal') {
-          // TODO: x axis should be scaleBand
           this.xAxisType = 'linear';
           this.yAxisType = 'linear';
-          this._thresholdType = 'x';
+          this.thresholdType = 'x';
         } else {
-          // TODO: y axis should be scaleBand
           this.xAxisType = 'linear';
           this.yAxisType = 'linear';
-          this._thresholdType = 'y';
+          this.thresholdType = 'y';
         }
         // update extents
         this.dataExtents = this._calcDataExtents(this.chartData);


### PR DESCRIPTION
Some small changes made during meeting with GE devs.

 - Changed to px-vis ‘register’ branch which has many fixes in framework
 - Removed useless emptyChart prop
 - Moving to use multi-layer SVG so we can vertically place components easily
 - Removed colored bar next to axis titles
 - Added support for vertical threshold line
 - Renamed seriesConfig to match how our data is formatted