### PR TITLE
Adding click events and flattening event data structure

### DIFF
--- a/demo/px-vis-boxplot-demo.html
+++ b/demo/px-vis-boxplot-demo.html
@@ -63,7 +63,7 @@
           on-box-mouseout="_handleBoxMouseout"
           on-outlier-click="_handleOutlierClick"
           on-outlier-mouseover="_handleOutlierMouseover"
-          on-outlier-mouseout="_handleOutlierMouseover">
+          on-outlier-mouseout="_handleOutlierMouseout">
         </px-vis-boxplot>
         <div>
           <button on-click="_add">Add</button>
@@ -309,28 +309,28 @@
 
     },
 
-    _handleBoxClick: function(event, data) {
-      this.eventMessage = 'Box click - ' + data.details.seriesKey;
+    _handleBoxClick: function(event, details) {
+      this.eventMessage = 'Box click - ' + details.seriesKey;
     },
 
-    _handleBoxMouseover: function(event, data) {
-      this.eventMessage = 'Box mouseover - ' + data.details.seriesKey;
+    _handleBoxMouseover: function(event, details) {
+      this.eventMessage = 'Box mouseover - ' + details.seriesKey;
     },
 
-    _handleBoxMouseout: function(event, data) {
-      this.eventMessage = 'Box mouseout - ' + data.details.seriesKey;
+    _handleBoxMouseout: function(event, details) {
+      this.eventMessage = 'Box mouseout - ' + details.seriesKey;
     },
 
-    _handleOutlierClick: function(event, data) {
-      this.eventMessage = 'Outlier click (' + data.details.data + ') - ' + data.details.seriesKey;
+    _handleOutlierClick: function(event, details) {
+      this.eventMessage = 'Outlier click (' + details.data + ') - ' + details.seriesKey;
     },
 
-    _handleOutlierMouseover: function(event, data) {
-      this.eventMessage = 'Outlier mouseover (' + data.details.data + ') - ' + data.details.seriesKey;
+    _handleOutlierMouseover: function(event, details) {
+      this.eventMessage = 'Outlier mouseover (' + details.data + ') - ' + details.seriesKey;
     },
 
-    _handleOutlierMouseout: function(event, data) {
-      this.eventMessage = 'Outlier mouseout (' + data.details.data + ') - ' + data.details.seriesKey;
+    _handleOutlierMouseout: function(event, details) {
+      this.eventMessage = 'Outlier mouseout (' + details.data + ') - ' + details.seriesKey;
     },
 
     _add: function() {

--- a/demo/px-vis-boxplot-demo.html
+++ b/demo/px-vis-boxplot-demo.html
@@ -57,7 +57,9 @@
           x-axis-config="[[props.xAxisConfig.value]]"
           y-axis-config="[[props.yAxisConfig.value]]"
           threshold-data="[[props.thresholdData.value]]"
-          threshold-config="[[props.thresholdConfig.value]]">
+          threshold-config="[[props.thresholdConfig.value]]"
+          on-box-click="_handleBoxClick"
+          on-outlier-click="_handleOutlierClick">
         </px-vis-boxplot>
         <div>
           <button on-click="_add">Add</button>
@@ -296,6 +298,16 @@
         }
       }
 
+    },
+
+    _handleBoxClick: function(event, data) {
+      console.log(event);
+      console.log(data);
+    },
+
+    _handleOutlierClick: function(event, data) {
+      console.log(event);
+      console.log(data);
     },
 
     _add: function() {

--- a/demo/px-vis-boxplot-demo.html
+++ b/demo/px-vis-boxplot-demo.html
@@ -59,13 +59,18 @@
           threshold-data="[[props.thresholdData.value]]"
           threshold-config="[[props.thresholdConfig.value]]"
           on-box-click="_handleBoxClick"
-          on-outlier-click="_handleOutlierClick">
+          on-box-mouseover="_handleBoxMouseover"
+          on-box-mouseout="_handleBoxMouseout"
+          on-outlier-click="_handleOutlierClick"
+          on-outlier-mouseover="_handleOutlierMouseover"
+          on-outlier-mouseout="_handleOutlierMouseover">
         </px-vis-boxplot>
         <div>
           <button on-click="_add">Add</button>
           <button on-click="_remove">Remove</button>
           <button on-click="_update">Update</button>
         </div>
+        <div id="eventMessages">Event: [[eventMessage]]</div>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
 
@@ -110,6 +115,10 @@
           }];
         }
       }
+    },
+
+    eventMessage: {
+      type: String
     },
 
     /**
@@ -301,13 +310,27 @@
     },
 
     _handleBoxClick: function(event, data) {
-      console.log(event);
-      console.log(data);
+      this.eventMessage = 'Box click - ' + data.details.seriesKey;
+    },
+
+    _handleBoxMouseover: function(event, data) {
+      this.eventMessage = 'Box mouseover - ' + data.details.seriesKey;
+    },
+
+    _handleBoxMouseout: function(event, data) {
+      this.eventMessage = 'Box mouseout - ' + data.details.seriesKey;
     },
 
     _handleOutlierClick: function(event, data) {
-      console.log(event);
-      console.log(data);
+      this.eventMessage = 'Outlier click (' + data.details.data + ') - ' + data.details.seriesKey;
+    },
+
+    _handleOutlierMouseover: function(event, data) {
+      this.eventMessage = 'Outlier mouseover (' + data.details.data + ') - ' + data.details.seriesKey;
+    },
+
+    _handleOutlierMouseout: function(event, data) {
+      this.eventMessage = 'Outlier mouseout (' + data.details.data + ') - ' + data.details.seriesKey;
     },
 
     _add: function() {

--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -358,6 +358,7 @@
             .attr('class', 'outlier')
             .on('mouseover', this._handleOutlierMouseover.bind(this))
             .on('mouseout', this._handleOutlierMouseout.bind(this))
+            .on('click', this._handleOutlierClick.bind(this))
             // run whenever data array gets updated
             .merge(outlierBuilder)
             .attr('d', Px.d3.symbol().type(this.markerMapping[this.outlierSymbol]).size(this.outlierSize))
@@ -370,7 +371,8 @@
 
         // attach box + whisker event handlers
         boxWhisker.on('mouseover', this._handleBoxMouseover.bind(this))
-          .on('mouseout', this._handleBoxMouseout.bind(this));
+          .on('mouseout', this._handleBoxMouseout.bind(this))
+          .on('click', this._handleBoxClick.bind(this));
       },
 
       /**
@@ -576,6 +578,17 @@
         });
       },
 
+      _handleBoxClick: function(d, i, svgEl) {
+        this.fire('box-click', {
+          details: {
+            seriesKey: this.seriesKey,
+            data: this.data,
+            position: this.position
+          },
+          svgEl: svgEl
+        });
+      },
+
       _handleOutlierMouseover: function(outlierValue, i, svgEl) {
         this.fire('outlier-mouseover', {
           details: {
@@ -589,6 +602,17 @@
 
       _handleOutlierMouseout: function(outlierValue, i, svgEl) {
         this.fire('outlier-mouseout', {
+          details: {
+            seriesKey: this.seriesKey,
+            data: outlierValue,
+            position: this.position
+          },
+          svgEl: svgEl[i]
+        });
+      },
+
+      _handleOutlierClick: function(outlierValue, i, svgEl) {
+        this.fire('outlier-click', {
           details: {
             seriesKey: this.seriesKey,
             data: outlierValue,

--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -558,66 +558,54 @@
 
       _handleBoxMouseover: function(d, i, svgEl) {
         this.fire('box-mouseover', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: this.data,
-            position: this.position
-          },
-          svgEl: svgEl
+          seriesKey: this.seriesKey,
+          data: this.data,
+          position: this.position,
+          svgEl: svgEl[i]
         });
       },
 
       _handleBoxMouseout: function(d, i, svgEl) {
         this.fire('box-mouseout', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: this.data,
-            position: this.position
-          },
-          svgEl: svgEl
+          seriesKey: this.seriesKey,
+          data: this.data,
+          position: this.position,
+          svgEl: svgEl[i]
         });
       },
 
       _handleBoxClick: function(d, i, svgEl) {
         this.fire('box-click', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: this.data,
-            position: this.position
-          },
-          svgEl: svgEl
+          seriesKey: this.seriesKey,
+          data: this.data,
+          position: this.position,
+          svgEl: svgEl[i]
         });
       },
 
       _handleOutlierMouseover: function(outlierValue, i, svgEl) {
         this.fire('outlier-mouseover', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: outlierValue,
-            position: this.position
-          },
+          seriesKey: this.seriesKey,
+          data: outlierValue,
+          position: this.position,
           svgEl: svgEl[i]
         });
       },
 
       _handleOutlierMouseout: function(outlierValue, i, svgEl) {
         this.fire('outlier-mouseout', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: outlierValue,
-            position: this.position
-          },
+          seriesKey: this.seriesKey,
+          data: outlierValue,
+          position: this.position,
           svgEl: svgEl[i]
         });
       },
 
       _handleOutlierClick: function(outlierValue, i, svgEl) {
         this.fire('outlier-click', {
-          details: {
-            seriesKey: this.seriesKey,
-            data: outlierValue,
-            position: this.position
-          },
+          seriesKey: this.seriesKey,
+          data: outlierValue,
+          position: this.position,
           svgEl: svgEl[i]
         });
       },

--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -479,7 +479,7 @@
       },
 
       _handleBoxMouseover: function(event, details) {
-        this._showTooltip(details.svgEl[0], this._createTooltipMessageBox(details.details));
+        this._showTooltip(details.svgEl, this._createTooltipMessageBox(details));
       },
 
       _handleBoxMouseout: function(event, details) {
@@ -487,7 +487,7 @@
       },
 
       _handleOutlierMouseover: function(event, details) {
-        this._showTooltip(details.svgEl, this._createTooltipMessageOutlier(details.details));
+        this._showTooltip(details.svgEl, this._createTooltipMessageOutlier(details));
       },
 
       _handleOutlierMouseout: function(event, details) {


### PR DESCRIPTION
Added outlier-click and box-click events.

Added event handlers back into demo. This is mainly for example reasons and to demonstrate they work.

Events now return ‘event’ and ‘details’ objects.

details: {
  seriesKey,
  data,
  position,
  svgEl
}