### PR TITLE
Enabling export using the px-vis-svg

### DIFF
--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../px-vis/px-vis-scale.html">
 <link rel="import" href="../px-vis/px-vis-svg.html">
-<link rel="import" href="../px-vis/px-vis-svg-canvas.html">
 <link rel="import" href="../px-vis/px-vis-axis.html">
 <link rel="import" href="../px-vis/px-vis-threshold.html">
 <link rel="import" href="../px-vis/px-vis-gridlines.html">
@@ -65,24 +64,13 @@ Custom property | Description
   <template>
     <style include="px-vis-boxplot-styles"></style>
 
-    <!-- TODO: change back to px-vis-svg once svg export works -->
-    <!-- <px-vis-svg
-      width="[[width]]"
-      height="[[height]]"
-      margin="[[margin]]"
-      svg="{{svg}}">
-    </px-vis-svg> -->
-    <px-vis-svg-canvas
-      id="svg"
-      class="inline--flex flex__item--msfix pointer-events"
+    <px-vis-svg
       width="[[width]]"
       height="[[height]]"
       margin="[[margin]]"
       svg="{{svg}}"
-      px-svg-elem="{{pxSvgElem}}"
-      canvas-context="{{canvasContext}}"
-      canvas-layers="{{canvasLayers}}">
-    </px-vis-svg-canvas>
+      px-svg-elem="{{pxSvgElem}}">
+    </px-vis-svg>
     <px-vis-scale
       x-axis-type="[[xAxisType]]"
       y-axis-type="[[yAxisType]]"
@@ -387,10 +375,6 @@ Custom property | Description
       ready: function() {
         this.set('numberOfLayers', 5);
         this.tooltipContent = this.$.tooltip.querySelector('#tooltipContent');
-        // TODO: remove this hack when export with svg works
-        // hack to remove the pointer-events: none set by the svg-canvas element
-        const svgStyleSheet = this.$.svg.shadowRoot.styleSheets[0];
-        svgStyleSheet.insertRule('.noPointer { pointer-events: all; }', svgStyleSheet.cssRules.length);
       },
 
       _chartDataChanged: function(chartData) {


### PR DESCRIPTION
Changed back to using px-vis-svg element.  Only thing to enable export is add the following prop to px-vis-svg:

px-svg-elem="{{pxSvgElem}}"