### PR TITLE
Force redraw axis after config change

### DIFF
--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -476,6 +476,7 @@ Custom property | Description
           return;
         }
         this._applyConfigToElement(xAxisConfig, this.$.xAxis);
+        this.$.xAxis.drawElement();
       },
 
       _yAxisConfigChanged: function(yAxisConfig) {
@@ -483,6 +484,7 @@ Custom property | Description
           return;
         }
         this._applyConfigToElement(yAxisConfig, this.$.yAxis);
+        this.$.yAxis.drawElement();
       },
 
       _thresholdConfigChanged: function(thresholdConfig) {


### PR DESCRIPTION
Fixes #47 

Some px-vis components don’t automatically redraw even if their config props change.  Added a single line to force axis components to redraw if their config changes.