### PR TITLE
Updating theme values

### DIFF
--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -229,36 +229,6 @@
           type: Object
         },
 
-        _defaultColor: {
-          type: String,
-          value: '#000'
-        },
-
-        _defaultAltColor: {
-          type: String,
-          value: '#FFF'
-        },
-
-        _defaultOutlierFillColor: {
-          type: String,
-          value: 'transparent'
-        },
-
-        _defaultOutlierMeanSymbol: {
-          type: String,
-          value: 'circle'
-        },
-
-        _defaultOutlierMeanSize: {
-          type: Number,
-          value: 10
-        },
-
-        _defaultOutlierMeanScale: {
-          type: Number,
-          value: 1
-        },
-
         /**
          * Observe changes to this in order to know when css vars have changed.
          */
@@ -652,21 +622,21 @@
           const seriesConfig = this.completeSeriesConfig || {};
           const config = seriesConfig[this.seriesKey] || {};
           this.fillColor = config.color
-            || this._checkThemeVariable('--px-vis-box-whisker-fill-color', this._defaultColor);
+            || this._checkThemeVariable('--px-vis-box-whisker-fill-color', '#000');
           this.strokeColor = config.strokeColor
-            || this._checkThemeVariable('--px-vis-box-whisker-stroke-color', this._defaultColor);
+            || this._checkThemeVariable('--px-vis-box-whisker-stroke-color', '#000');
           this.medianColor = config.medianColor
-            || this._checkThemeVariable('--px-vis-box-whisker-median-color', this._defaultAltColor);
+            || this._checkThemeVariable('--px-vis-box-whisker-median-color', '#FFF');
           this.medianWidth = config.medianWidth
             || this._checkThemeVariable('--px-vis-box-whisker-median-width', '1px');
           this.meanStrokeColor = config.meanStrokeColor
             || this._checkThemeVariable('--px-vis-box-whisker-mean-color', this.strokeColor);
           this.meanFillColor = config.meanFillColor
-            || this._checkThemeVariable('--px-vis-box-whisker-mean-fill-color', this._defaultAltColor);
+            || this._checkThemeVariable('--px-vis-box-whisker-mean-fill-color', '#FFF');
           this.outlierStrokeColor = config.outlierStrokeColor
             || this._checkThemeVariable('--px-vis-box-whisker-outlier-color', this.strokeColor);
           this.outlierFillColor = config.outlierFillColor
-            || this._checkThemeVariable('--px-vis-box-whisker-outlier-fill-color', this._defaultOutlierFillColor);
+            || this._checkThemeVariable('--px-vis-box-whisker-outlier-fill-color', 'transparent');
           // notify children
           let comps;
           if (this.shadowRoot) {
@@ -691,19 +661,13 @@
         const seriesConfig = this.completeSeriesConfig || {};
         const config = seriesConfig[this.seriesKey] || {};
         // outlier options
-        this.outlierSymbol = config.outlierSymbol
-          || this._defaultOutlierMeanSymbol;
-        this.outlierSize = config.outlierSize
-          || this._defaultOutlierMeanSize;
-        this.outlierScale = config.outlierScale
-          || this._defaultOutlierMeanScale;
+        this.outlierSymbol = config.outlierSymbol || 'circle';
+        this.outlierSize = config.outlierSize || 10;
+        this.outlierScale = config.outlierScale || 1;
         // mean options
-        this.meanSymbol = config.meanSymbol
-          || this._defaultOutlierMeanSymbol;
-        this.meanSize = config.meanSize
-          || this._defaultOutlierMeanSize;
-        this.meanScale = config.meanScale
-          || this._defaultOutlierMeanScale;
+        this.meanSymbol = config.meanSymbol || 'circle';
+        this.meanSize = config.meanSize || 10;
+        this.meanScale = config.meanScale || 1;
       }
 
     });

--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -177,6 +177,13 @@
         },
 
         /**
+         * Stroke width for the median line. This value is ready from the completeSeriesConfig.
+         */
+        medianWidth: {
+          type: String
+        },
+
+        /**
          * Stroke color for mean circle. This value is ready from the completeSeriesConfig.
          */
         meanStrokeColor: {
@@ -345,13 +352,13 @@
 
         // draw all lines and rectangles
         // TODO: replace basic append methods with D3 way of doing it, such as for mean and outliers
-        this._appendLine(boxWhisker, drawingData.max, this.strokeColor);
-        this._appendLine(boxWhisker, drawingData.q3Whisker, this.strokeColor);
+        this._appendLine(boxWhisker, drawingData.max, this.strokeColor, '1px');
+        this._appendLine(boxWhisker, drawingData.q3Whisker, this.strokeColor, '1px');
         this._appendRectangle(boxWhisker, drawingData.q3Box, this.strokeColor, this.fillColor);
         this._appendRectangle(boxWhisker, drawingData.q1Box, this.strokeColor, this.fillColor);
-        this._appendLine(boxWhisker, drawingData.q1Whisker, this.strokeColor);
-        this._appendLine(boxWhisker, drawingData.min, this.strokeColor);
-        this._appendLine(boxWhisker, drawingData.median, this.medianColor);
+        this._appendLine(boxWhisker, drawingData.q1Whisker, this.strokeColor, '1px');
+        this._appendLine(boxWhisker, drawingData.min, this.strokeColor, '1px');
+        this._appendLine(boxWhisker, drawingData.median, this.medianColor, this.medianWidth);
 
         // draw mean with D3 for symbol/customization support
         const meanBuilder = boxWhisker.selectAll('path.mean')
@@ -414,13 +421,14 @@
       /**
        * Draw a single straight line to an existing svg element.
        */
-      _appendLine: function(svg, data, strokeColor) {
+      _appendLine: function(svg, data, strokeColor, strokeWidth) {
         return svg.append('line')
           .attr('x1', data.x1)
           .attr('y1', data.y1)
           .attr('x2', data.x2)
           .attr('y2', data.y2)
-          .attr('stroke', strokeColor);
+          .attr('stroke', strokeColor)
+          .attr('stroke-width', strokeWidth);
       },
 
       /**
@@ -649,6 +657,8 @@
             || this._checkThemeVariable('--px-vis-box-whisker-stroke-color', this._defaultColor);
           this.medianColor = config.medianColor
             || this._checkThemeVariable('--px-vis-box-whisker-median-color', this._defaultAltColor);
+          this.medianWidth = config.medianWidth
+            || this._checkThemeVariable('--px-vis-box-whisker-median-width', '1px');
           this.meanStrokeColor = config.meanStrokeColor
             || this._checkThemeVariable('--px-vis-box-whisker-mean-color', this.strokeColor);
           this.meanFillColor = config.meanFillColor

--- a/px-vis-box-whisker.html
+++ b/px-vis-box-whisker.html
@@ -313,8 +313,6 @@
           return;
         }
 
-        // make sure all options are up to date
-        this._resolveOptions();
         // init svg group
         this._svgGroup = this.svg.append('g');
         // group together box + whisker parts
@@ -621,6 +619,7 @@
         this.debounce('resolve-css-vars', function() {
           const seriesConfig = this.completeSeriesConfig || {};
           const config = seriesConfig[this.seriesKey] || {};
+          // check css vars
           this.fillColor = config.color
             || this._checkThemeVariable('--px-vis-box-whisker-fill-color', '#000');
           this.strokeColor = config.strokeColor
@@ -633,10 +632,19 @@
             || this._checkThemeVariable('--px-vis-box-whisker-mean-color', this.strokeColor);
           this.meanFillColor = config.meanFillColor
             || this._checkThemeVariable('--px-vis-box-whisker-mean-fill-color', '#FFF');
+          this.meanSize = this._removePx(config.meanSize
+            || this._checkThemeVariable('--px-vis-box-whisker-mean-size', 10));
           this.outlierStrokeColor = config.outlierStrokeColor
             || this._checkThemeVariable('--px-vis-box-whisker-outlier-color', this.strokeColor);
           this.outlierFillColor = config.outlierFillColor
             || this._checkThemeVariable('--px-vis-box-whisker-outlier-fill-color', 'transparent');
+          this.outlierSize = this._removePx(config.outlierSize
+            || this._checkThemeVariable('--px-vis-box-whisker-outlier-size', 10));
+          // TODO: add css vars
+          this.outlierSymbol = config.outlierSymbol || 'circle';
+          this.outlierScale = config.outlierScale || 1;
+          this.meanSymbol = config.meanSymbol || 'circle';
+          this.meanScale = config.meanScale || 1;
           // notify children
           let comps;
           if (this.shadowRoot) {
@@ -654,20 +662,12 @@
         }.bind(this), 10);
       },
 
-      _resolveOptions: function() {
-        if (this.hasUndefinedArguments(arguments)) {
-          return;
+      _removePx: function(str) {
+        if (str && typeof str === 'string') {
+          return str.replace('px', '');
+        } else {
+          return str;
         }
-        const seriesConfig = this.completeSeriesConfig || {};
-        const config = seriesConfig[this.seriesKey] || {};
-        // outlier options
-        this.outlierSymbol = config.outlierSymbol || 'circle';
-        this.outlierSize = config.outlierSize || 10;
-        this.outlierScale = config.outlierScale || 1;
-        // mean options
-        this.meanSymbol = config.meanSymbol || 'circle';
-        this.meanSize = config.meanSize || 10;
-        this.meanScale = config.meanScale || 1;
       }
 
     });

--- a/sass/px-vis-boxplot-dark-theme.scss
+++ b/sass/px-vis-boxplot-dark-theme.scss
@@ -10,6 +10,7 @@
    --px-vis-box-whisker-fill-color: $violet1;
    --px-vis-box-whisker-stroke-color: $violet1;
    --px-vis-box-whisker-median-color: $violet8;
+   --px-vis-box-whisker-median-width: 2px;
    --px-vis-box-whisker-mean-color: $violet1;
    --px-vis-box-whisker-mean-fill-color: $gray18;
    --px-vis-box-whisker-outlier-color: $violet1;

--- a/sass/px-vis-boxplot-dark-theme.scss
+++ b/sass/px-vis-boxplot-dark-theme.scss
@@ -13,8 +13,10 @@
    --px-vis-box-whisker-median-width: 2px;
    --px-vis-box-whisker-mean-color: $violet1;
    --px-vis-box-whisker-mean-fill-color: $gray18;
+   --px-vis-box-whisker-mean-size: 20px;
    --px-vis-box-whisker-outlier-color: $violet1;
    --px-vis-box-whisker-outlier-fill-color: transparent;
+   --px-vis-box-whisker-outlier-size: 15px;
 
    // threshold
    --px-vis-threshold-color: $orange6;

--- a/sass/px-vis-boxplot-light-theme.scss
+++ b/sass/px-vis-boxplot-light-theme.scss
@@ -13,8 +13,10 @@ html {
   --px-vis-box-whisker-median-width: 2px;
   --px-vis-box-whisker-mean-color: $pink7;
   --px-vis-box-whisker-mean-fill-color: $white;
+  --px-vis-box-whisker-mean-size: 20px;
   --px-vis-box-whisker-outlier-color: $pink7;
   --px-vis-box-whisker-outlier-fill-color: transparent;
+  --px-vis-box-whisker-outlier-size: 15px;
 
   // threshold
   --px-vis-threshold-color: $yellow-green6;

--- a/sass/px-vis-boxplot-light-theme.scss
+++ b/sass/px-vis-boxplot-light-theme.scss
@@ -10,6 +10,7 @@ html {
   --px-vis-box-whisker-fill-color: $pink7;
   --px-vis-box-whisker-stroke-color: $pink7;
   --px-vis-box-whisker-median-color: $purple1;
+  --px-vis-box-whisker-median-width: 2px;
   --px-vis-box-whisker-mean-color: $pink7;
   --px-vis-box-whisker-mean-fill-color: $white;
   --px-vis-box-whisker-outlier-color: $pink7;


### PR DESCRIPTION
Fixes for #50 and #51

Adding css vars for the following:
 * `--px-vis-box-whisker-mean-size`
 * `--px-vis-box-whisker-outlier-size`
 * `--px-vis-box-whisker-median-width`

Setting values to these new vars in the theme files to match specs.  I also removed props that defined the default values in order to be more consistent with other predix components.