### PR TITLE
Making paddingOuter a private var

### DIFF
--- a/demo/px-vis-boxplot-demo.html
+++ b/demo/px-vis-boxplot-demo.html
@@ -51,7 +51,6 @@
           height="[[props.height.value]]"
           series-config="[[props.seriesConfig.value]]"
           scale-padding="[[props.scalePadding.value]]"
-          padding-outer="[[props.paddingOuter.value]]"
           orientation="[[props.orientation.value]]"
           hover-opacity="[[props.hoverOpacity.value]]"
           hide-grid-lines="[[props.hideGridLines.value]]"
@@ -212,12 +211,6 @@
       },
 
       scalePadding: {
-        type: Number,
-        inputType: 'text',
-        defaultValue: '0.5'
-      },
-
-      paddingOuter: {
         type: Number,
         inputType: 'text',
         defaultValue: '0.5'

--- a/px-vis-boxplot.html
+++ b/px-vis-boxplot.html
@@ -304,14 +304,6 @@ Custom property | Description
         },
 
         /**
-         * Padding seperating the axis and the box and whisker drawings.
-         */
-        paddingOuter: {
-          type: Number,
-          value: 0.5
-        },
-
-        /**
          * Direction of the box plot chart.  The values can be
          * 'vertical' or 'horizontal'.
          */
@@ -376,6 +368,14 @@ Custom property | Description
         },
 
         /**
+         * Padding seperating the axis and the box and whisker drawings.
+         */
+        _paddingOuter: {
+          type: Number,
+          value: 0.5
+        },
+
+        /**
          * Observe changes to this in order to know when css vars have changed.
          */
         _stylesResolved: {
@@ -386,7 +386,7 @@ Custom property | Description
       },
 
       observers: [
-        '_chartDataChanged(chartData, chartData.*, scalePadding, paddingOuter)',
+        '_chartDataChanged(chartData, chartData.*, scalePadding, _paddingOuter)',
         '_boxWhiskerConfigChanged(boxWhiskerConfig)',
         '_orientationChanged(orientation)',
         '_xAxisConfigChanged(xAxisConfig)',
@@ -596,7 +596,7 @@ Custom property | Description
         const scaleFunc = this.orientation === 'horizontal' ? this.y : this.x;
         if (scaleFunc.paddingOuter) {
           // update outer padding manually
-          scaleFunc.paddingOuter(this.paddingOuter);
+          scaleFunc.paddingOuter(this._paddingOuter);
           // update box width and edge width, they are dependend on scalePadding and paddingOuter
           this._boxWidth = scaleFunc.bandwidth();
           this._edgeWidth = this._boxWidth / 3;


### PR DESCRIPTION
Fixes #44

`paddingOuter` is needed for proper spacing, but now it is a private var with an underscore (`_paddingOuter`).  It was also removed from the demo props.